### PR TITLE
Fixes #34: player (abbot) now starts at centre of a tile

### DIFF
--- a/game/entities/abbot.py
+++ b/game/entities/abbot.py
@@ -3,11 +3,11 @@ import pygame
 
 class Abbot:
     def __init__(self, x, y, grid_size):
-        self.x = x
-        self.y = y
         self.grid_size = grid_size
-        self.target_x = x  # Target position
-        self.target_y = y
+        self.x = (x // grid_size) * grid_size + grid_size // 2
+        self.y = (y // grid_size) * grid_size + grid_size // 2
+        self.target_x = self.x  # Target position
+        self.target_y = self.y
         self.radius = 10
         self.speed = 5  # Movement speed
 

--- a/planning/MVP-G1.md
+++ b/planning/MVP-G1.md
@@ -136,7 +136,7 @@
 
 ## Outcome:
 By the end of the week, you will have a simple game where:
-- [ ] The player can move around the screen.
+- [x] The player can move around the screen.
 - [ ] Basic resources (e.g., food, monks) are collected.
 - [ ] The player can track their progress and potentially save/load their game.
 


### PR DESCRIPTION
Fixes #34

### Description
This pull request fixes the issue where the abbot starts at the intersection of grid tiles instead of the center of a grid tile.

### Changes
- Adjusted the initial position of the abbot to be centered within a grid tile.

### Related Issue
Fixes #34